### PR TITLE
force fix serving url

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def image_url():
 	filepath = (bucket + "/" + image)
 
 	try:
-		servingImage = images.get_serving_url(None, filename='/gs/' + filepath)
+		servingImage = images.get_serving_url(None, filename='/gs/' + filepath, secure_url=True)
 	except images.AccessDeniedError:
 		error = json.dumps({'error': 'Ensure the GAE service account has access to the object in Google Cloud Storage.'})
 		return json_response(error, 401)

--- a/main.py
+++ b/main.py
@@ -23,9 +23,12 @@ def image_url():
 		return json_response(error, 422)
 
 	filepath = (bucket + "/" + image)
+	filename='/gs/' + filepath
+	blob_key=blobstore.create_gs_key(filename)
+	images.delete_serving_url(blob_key)
 
 	try:
-		servingImage = images.get_serving_url(None, filename='/gs/' + filepath, secure_url=True)
+		servingImage = images.get_serving_url(blob_key, filename='/gs/' + filepath, secure_url=True)
 	except images.AccessDeniedError:
 		error = json.dumps({'error': 'Ensure the GAE service account has access to the object in Google Cloud Storage.'})
 		return json_response(error, 401)


### PR DESCRIPTION
- Create blob_key for each gcs object and then
- Delete Serving URL before getting the serving url

Caveats: This potentially makes the get_serving_url endpoint very very slow since the delete_serving_url API can be nasty. We may have to hide this feature behind a query arg